### PR TITLE
Add optional traceparent attribute for distributed tracing

### DIFF
--- a/uprotocol/uattributes.proto
+++ b/uprotocol/uattributes.proto
@@ -75,6 +75,9 @@ message UAttributes {
 
     // Authorization token used for TAP per https://github.com/eclipse-uprotocol/uprotocol-spec/blob/main/basics/permissions.adoc[Permissions]
     optional string token = 9;
+
+    // Optional identifier used to correlate observability across related events
+    optional string traceparent = 10;
 }
 
 


### PR DESCRIPTION
Prerequisite PR for uProtocol spec [Issue 49](https://github.com/eclipse-uprotocol/up-spec/issues/49).  Once merged, the release will need to be tagged and the up-java PR will need to be updated with the new tag.