### PR TITLE
Add back in javadoc plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,6 +115,20 @@
 
             <!-- requirement plugins -->
             <plugin>
+               <groupId>org.apache.maven.plugins</groupId>
+               <artifactId>maven-javadoc-plugin</artifactId>
+               <version>3.6.0</version>
+               <executions>
+                  <execution>
+                    <id>attach-javadocs</id>
+                    <goals>
+                       <goal>jar</goal>
+                    </goals>
+                  </execution>
+              </executions>
+            </plugin>    
+
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
                 <version>3.0.1</version>


### PR DESCRIPTION
This was removed in error and now the project cannot be released to maven as it is required.