### PR TITLE
Fix UAttributes integer type

### DIFF
--- a/uprotocol/uattributes.proto
+++ b/uprotocol/uattributes.proto
@@ -28,6 +28,7 @@
 
  import "uri.proto";
  import "uuid.proto";
+ import "ustatus.proto";
  import "uprotocol_options.proto";
 
  option java_package = "org.eclipse.uprotocol.v1";
@@ -61,7 +62,7 @@ message UAttributes {
     UPriority priority = 5;
 
     // TTL is How long this message should live for after it was generated (in milliseconds). If not present,
-    // the message is assumed to not timeout (should live forever)
+    // or 0 (zero), the message is assumed to not timeout (i.e. live forever).<br>
     // Event expires when:
     // \$t_current > t_{id} + ttl\$
     optional uint32 ttl = 6;
@@ -71,9 +72,8 @@ message UAttributes {
 
     // Communication error attribute populated by uP-L2 dispatchers only when an error 
     // has occurred in the delivery of RPC request or response events. 
-    // The contents of this attribute, if present, is the unsigned integer representation of
-    // UCode. If the attribute is not present, there is no communication error
-    optional uint32 commstatus = 8;
+    // If the attribute is not present, there is no communication error
+    optional UCode commstatus = 8;
 
     // The correlation ID (UUDI) passed for response type messages to corelate the 
     // response to a request.

--- a/uprotocol/uattributes.proto
+++ b/uprotocol/uattributes.proto
@@ -87,6 +87,23 @@ message UAttributes {
 }
 
 
+// Message that defines a subset of UAttributes used for RPC Method invocation
+message CallOptions {
+    // Message priority per 
+    // https://github.com/eclipse-uprotocol/uprotocol-spec/blob/main/basics/qos.adoc[uProtocol Prioritization]
+    UPriority priority = 1;
+
+    // TTL is How long this message should live for after it was generated (in milliseconds). If not present,
+    // or 0 (zero), the message is assumed to not timeout (i.e. live forever).<br>
+    // Event expires when:
+    // \$t_current > t_{id} + ttl\$
+    optional uint32 ttl = 2;
+    
+    // Authorization token used for TAP per https://github.com/eclipse-uprotocol/uprotocol-spec/blob/main/basics/permissions.adoc[Permissions]
+    optional string token = 3;
+}
+
+
 // uProtocol defines message types. Using the message type, validation can be performed to ensure transport
 // validity of the data in the {@link UAttributes}.
 enum UMessageType {

--- a/uprotocol/uattributes.proto
+++ b/uprotocol/uattributes.proto
@@ -60,19 +60,20 @@ message UAttributes {
     // https://github.com/eclipse-uprotocol/uprotocol-spec/blob/main/basics/qos.adoc[uProtocol Prioritization]
     UPriority priority = 5;
 
-    // TTL is How long this message should live for after it was generated (in milliseconds).
+    // TTL is How long this message should live for after it was generated (in milliseconds). If not present,
+    // the message is assumed to not timeout (should live forever)
     // Event expires when:
     // \$t_current > t_{id} + ttl\$
-    optional int32 ttl = 6;
+    optional uint32 ttl = 6;
     
     // Permission level per https://github.com/eclipse-uprotocol/uprotocol-spec/blob/main/basics/permissions.adoc[Permissions]
-    optional int32 permission_level = 7;
+    optional uint32 permission_level = 7;
 
     // Communication error attribute populated by uP-L2 dispatchers only when an error 
     // has occurred in the delivery of RPC request or response events. 
     // The contents of this attribute, if present, is the unsigned integer representation of
-    // UCode
-    optional int32 commstatus = 8;
+    // UCode. If the attribute is not present, there is no communication error
+    optional uint32 commstatus = 8;
 
     // The correlation ID (UUDI) passed for response type messages to corelate the 
     // response to a request.


### PR DESCRIPTION
There are a number of integer values that do not need to be signed but was set at int32 in lieu of uint32 by mistake, this change addresses the discrepancy. We also elaborate on what is means when the attribute is not present.

#106