### PR TITLE
Change uTwin version to v2

### DIFF
--- a/uprotocol/core/utwin/v2/utwin.proto
+++ b/uprotocol/core/utwin/v2/utwin.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 General Motors GTO LLC
+ * Copyright (c) 2024 General Motors GTO LLC
  *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -19,7 +19,7 @@
  * under the License.
  *
  * SPDX-FileType: SOURCE
- * SPDX-FileCopyrightText: 2023 General Motors GTO LLC
+ * SPDX-FileCopyrightText: 2024 General Motors GTO LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 syntax = "proto3";
@@ -38,7 +38,7 @@ option java_multiple_files = true;
 // uTwin Service interface definition
 service uTwin {
   option (name) = "core.utwin"; // Service name
-  option (version_major) = 1;
+  option (version_major) = 2;
   option (version_minor) = 0;
   option (id) = 26;
 


### PR DESCRIPTION
The uProtocol 1.3.6 version that uses CloudEvents will be v1 so the Eclipse version that uses UMessage MUST be v2 to follow semver requirements.

#110