### PR TITLE
Marking the branch READ-ONLY

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,31 +1,3 @@
-image:https://github.com/eclipse-uprotocol/.github/raw/main/logo/uprotocol_logo.png[uProtocol, width=640]
+**PROJECT IS NOW READ ONLY** 
 
-image:https://img.shields.io/badge/License-Apache%202.0-blue.svg[License,link=https://opensource.org/licenses/Apache-2.0]
-
-*NOTE:* _Please refer to https://github.com/eclipse-uprotocol/uprotocol-spec[] for more information about uProtocol_
-
-== Overview
-
-This project contains the core data models (UUri, UAttributes, etc..) and core services definitions (uDiscovery, uSubscription, uTwin) of uProtocol. This project is used by other uprotocol projects such as the language specific SDKs and uLink library that extend the data model to add validators, serializers, and factory/builder methods.
-
-
-=== How To Build?
-
-The Project uses maven to build the protobuf message. The target to build the code is:
-
-[source,bash]
-----
-mvn verify -f "pom.xml"
-----
-
-=== How To Use?
-To pull the built (java) artifacts from maven central, add the following dependency to your pom.xml file:
-[source]
-----
-<!-- uProtocol Core -->
-<dependency>
-    <groupId>org.eclipse.uprotocol</groupId>
-    <artifactId>uprotocol-core-api</artifactId>
-    <version>1.5.0</version>
-</dependency>
-----
+up-core-api has merged with https://github.com/eclipse-uprotocol/up-spec[up-spec] so that the project specs and core apis can be released/labeled together. Please refer to https://github.com/eclipse-uprotocol/up-spec/up-core-api[up-spec/up-core-api] for more information.


### PR DESCRIPTION
The following change will change the main readme to state that the protos in the core-api have moved to up-spec so that the specifications and core apis can be released and labeled together.  Any future changes to the core APIs need to be made on the up-spec project.