### PR TITLE
Urgent fix in uTwin package Definition

### DIFF
--- a/uprotocol/core/utwin/v2/utwin.proto
+++ b/uprotocol/core/utwin/v2/utwin.proto
@@ -24,14 +24,14 @@
  */
 syntax = "proto3";
 
-package uprotocol.core.utwin.v1;
+package uprotocol.core.utwin.v2;
 
 import "uprotocol_options.proto";
 import "ustatus.proto";
 import "uri.proto";
 import "umessage.proto";
 
-option java_package = "org.eclipse.uprotocol.core.utwin.v1";
+option java_package = "org.eclipse.uprotocol.core.utwin.v2";
 option java_outer_classname = "UTwinProto";
 option java_multiple_files = true;
 

--- a/uprotocol/uprotocol_options.proto
+++ b/uprotocol/uprotocol_options.proto
@@ -92,7 +92,7 @@ extend google.protobuf.EnumValueOptions {
 message UServiceTopic {
   // The topic id. <br>
   // * *MUST* be unique within the uService scope
-  // * *MUST* start at 0x800h
+  // * *MUST* start at 0x8000h
   uint32 id = 1;
   
   // Topic name represented as a string


### PR DESCRIPTION
uTwin was changed from v1 to v2 because we were going to call the original uTwin API that used cloudevents as V1 however the package name was not fixed in the proto causing build issues.  This fix addresses that problem as well as a minor document change in uprotocol_options.proto for the topic ID number.